### PR TITLE
refactor: clean up testthat.R

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,34 +1,4 @@
 library(testthat)
-library(Spectra)
-library(MsExperiment)
-library(faahKO)
 library(MsIO)
-
-# BackendMzR object
-sciex_file <- normalizePath(
-    dir(system.file("sciex", package = "msdata"), full.names = TRUE))
-sciex_mzr <- backendInitialize(MsBackendMzR(), files = sciex_file)
-
-# Spectra object
-fl <- system.file("TripleTOF-SWATH", "PestMix1_DDA.mzML",
-                  package = "msdata")
-sps_dda <- Spectra(fl)
-## add processingQueueVariables to test export
-sps_dda@processingQueueVariables <- c(sps_dda@processingQueueVariables, "rtime")
-sps_dda <- filterMzRange(sps_dda, c(200,300))
-sps_dda <- filterRt(sps_dda, c(200, 700)) ## to ensure subsetted object would work
-
-# MsExperiment object (any easier way ?)
-faahko_3_files <- c(system.file('cdf/KO/ko15.CDF', package = "faahKO"),
-                    system.file('cdf/KO/ko16.CDF', package = "faahKO"),
-                    system.file('cdf/KO/ko18.CDF', package = "faahKO"))
-fls <- normalizePath(faahko_3_files)
-df <- data.frame(mzML_file = basename(fls),
-                 dataOrigin = fls,
-                 sample = c("ko15", "ko16", "ko18"))
-mse <- readMsExperiment(spectraFiles = fls, sampleData = df)
-## add processingQueueVariables to test export
-mse_filt <- filterMzRange(mse, c(200, 500))
-mse_filt <- filterRt(mse_filt, c(3000, 3500))
 
 test_check("MsIO")

--- a/tests/testthat/test_MsBackendMzR.R
+++ b/tests/testthat/test_MsBackendMzR.R
@@ -1,3 +1,9 @@
+library(Spectra)
+
+sciex_file <- normalizePath(
+    dir(system.file("sciex", package = "msdata"), full.names = TRUE))
+sciex_mzr <- backendInitialize(MsBackendMzR(), files = sciex_file)
+
 test_that("saveMsObject,readMsObject,PlainTextParam,MsBackendMzR works", {
     b <- sciex_mzr
     pth <- file.path(tempdir(), "test_backend")

--- a/tests/testthat/test_MsExperiment.R
+++ b/tests/testthat/test_MsExperiment.R
@@ -1,3 +1,18 @@
+library(MsExperiment)
+library(faahKO)
+
+faahko_3_files <- c(system.file('cdf/KO/ko15.CDF', package = "faahKO"),
+                    system.file('cdf/KO/ko16.CDF', package = "faahKO"),
+                    system.file('cdf/KO/ko18.CDF', package = "faahKO"))
+fls <- normalizePath(faahko_3_files)
+df <- data.frame(mzML_file = basename(fls),
+                 dataOrigin = fls,
+                 sample = c("ko15", "ko16", "ko18"))
+mse <- readMsExperiment(spectraFiles = fls, sampleData = df)
+## add processingQueueVariables to test export
+mse_filt <- filterMzRange(mse, c(200, 500))
+mse_filt <- filterRt(mse_filt, c(3000, 3500))
+
 test_that("saveMsObject,readMsObject,PlainTextParam,MsExperiment works", {
     pth <- file.path(tempdir(), "test_MsExperiment")
     param <- PlainTextParam(path = pth)

--- a/tests/testthat/test_Spectra.R
+++ b/tests/testthat/test_Spectra.R
@@ -1,3 +1,13 @@
+library(Spectra)
+
+fl <- system.file("TripleTOF-SWATH", "PestMix1_DDA.mzML",
+                  package = "msdata")
+sps_dda <- Spectra(fl)
+## add processingQueueVariables to test export
+sps_dda@processingQueueVariables <- c(sps_dda@processingQueueVariables, "rtime")
+sps_dda <- filterMzRange(sps_dda, c(200,300))
+sps_dda <- filterRt(sps_dda, c(200, 700)) ## to ensure subsetted object would work
+
 test_that("saveMsObject,readMsObject,PlainTextParam,Spectra works", {
     s <- sps_dda
     pth <- file.path(tempdir(), "test_spectra")

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -1,4 +1,5 @@
 library(xcms)
+
 xmse <- loadXcmsData()
 xmseg_filt <- filterMzRange(xmse, c(200, 500))
 xmseg_filt <- filterRt(xmseg_filt, c(3000, 4000))


### PR DESCRIPTION
Just moved code from the *testthat.R* into the respective unit tests for the various objects. That way we keep the testthat file clean - and assure that the individual unit tests are not affected by the libraries loaded in the individual unit test files.

variables that would be shared/used in more than one unit test file should however go back to testthat.R - but I haven't seen any so far (?)