### PR TITLE
quick fixes for import from MetaboLights

### DIFF
--- a/R/MsExperiment.R
+++ b/R/MsExperiment.R
@@ -253,7 +253,6 @@ setMethod("readMsObject",
               # merging
               ord <- match(assay_data$`Sample Name`, sample_info$`Sample Name`)
               merged_data <- cbind(assay_data, sample_info[ord, ])
-              names(merged_data) <- gsub(" ", "_", names(merged_data))
               if (keepProtocol || keepOntology || simplify)
                   merged_data <- .clean_merged(x = merged_data,
                                                keepProtocol = keepProtocol,
@@ -284,17 +283,8 @@ setMethod("readMsObject",
 
 #####HELPERS
 
-#' function that takes the extra parameters and clean the metadata if asked by
+#' Function that takes the extra parameters and clean the metadata if asked by
 #' the user.
-#'
-#' Note:  the subsetting of the merged data is done here, which WILL rename the
-#' duplicated columns. I could fix that by first transforming the data.frame into
-#' a list but I am not sure that it is useful.. The user might do some
-#' subsetting too later and then the same thing will happen. Might as well have
-#' it from the beginning.
-#'
-#' Note2: I would move that function later, keeping it her for review to help
-#' clarity
 #'
 #' @noRd
 .clean_merged <- function(x, keepProtocol, keepOntology, simplify) {

--- a/R/MsExperiment.R
+++ b/R/MsExperiment.R
@@ -267,15 +267,17 @@ setMethod("readMsObject",
 
               ## sample to spectra link
               fl <- object@spectra@backend@spectraData[1, "derived_spectral_data_file"]
-              nme <- colnames(merged_data)[which(merged_data[1, ] == fl)]
+              idx <- which(merged_data[1, ,drop = TRUE] == fl)
+              nme <- colnames(merged_data)[idx]
               merged_data <- merged_data[grepl(param@filePattern,
                                                merged_data[, nme]), ]
-              nme <- gsub(" ", "_", nme) #use concatenate instead ?
+              nme <- gsub(" ", "_", nme)
+              colnames(merged_data)[idx] <- nme
               object@sampleData <- DataFrame(merged_data, check.names = FALSE)
               object <- MsExperiment::linkSampleData(object,
                                                      with = paste0("sampleData.",
                                                                 nme,
-                                                                "= spectra.derived_spectral_data_file"))
+                                                                 "= spectra.derived_spectral_data_file"))
               validObject(object)
               object
           })

--- a/R/MsExperiment.R
+++ b/R/MsExperiment.R
@@ -273,7 +273,8 @@ setMethod("readMsObject",
                                                merged_data[, nme]), ]
               nme <- gsub(" ", "_", nme)
               colnames(merged_data)[idx] <- nme
-              object@sampleData <- DataFrame(merged_data, check.names = FALSE)
+              object@sampleData <- DataFrame(merged_data, check.names = FALSE,
+                                             row.names = NULL)
               object <- MsExperiment::linkSampleData(object,
                                                      with = paste0("sampleData.",
                                                                 nme,


### PR DESCRIPTION
Hi fixed these things below: 

- The naming stays the same as for MetaboLights (except for Derived_Spectral_Data_File, because the link between spectra to sample does not work otherwise.)
- Fix the creation of rownames in the DataFrame of the sampleData